### PR TITLE
Add hostname to socketid

### DIFF
--- a/lib/rpc_socket.js
+++ b/lib/rpc_socket.js
@@ -24,6 +24,7 @@
 "use strict";
 
 const events = require('events');
+const os = require('os');
 
 // this is a separate function to keep the environment clean
 // and avoid spurious live objects
@@ -71,7 +72,7 @@ class RpcSocket extends events.EventEmitter {
         this._callId = 0;
         this._ended = false;
         this._stubCnt = 0;
-        this._socketId = `${process.pid}:${socketId ++}:`;
+        this._socketId = `${os.hostname()}-${process.pid}:${socketId ++}:`;
 
         this._socket.on('data', this._handleMessage.bind(this));
 


### PR DESCRIPTION
Process id may not be unique enough in kubernetes environment as most pod starts the process with id 1.